### PR TITLE
don't support pathlib.Path and other StrPaths on python 3.5

### DIFF
--- a/stdlib/2and3/tarfile.pyi
+++ b/stdlib/2and3/tarfile.pyi
@@ -159,12 +159,25 @@ class TarFile(Iterable[TarInfo]):
         def chown(self, tarinfo: TarInfo, targetpath: AnyPath) -> None: ...  # undocumented
     def chmod(self, tarinfo: TarInfo, targetpath: AnyPath) -> None: ...  # undocumented
     def utime(self, tarinfo: TarInfo, targetpath: AnyPath) -> None: ...  # undocumented
+    # 3.7: exclude removed
+    # 3.6: any StrPath works instead of just str (not documented)
     if sys.version_info >= (3, 7):
+        def add(
+            self,
+            # name and arcname get converted to str in gettarinfo(), which needs str for using os.sep
+            name: StrPath,
+            arcname: Optional[StrPath] = ...,
+            recursive: bool = ...,
+            *,
+            filter: Optional[Callable[[TarInfo], Optional[TarInfo]]] = ...,
+        ) -> None: ...
+    elif sys.version_info >= (3, 6):
         def add(
             self,
             name: StrPath,
             arcname: Optional[StrPath] = ...,
             recursive: bool = ...,
+            exclude: Optional[Callable[[str], bool]] = ...,
             *,
             filter: Optional[Callable[[TarInfo], Optional[TarInfo]]] = ...,
         ) -> None: ...


### PR DESCRIPTION
If you merge this pull request, then it becomes a part of your pull request to typeshed (so that your pull request to typeshed contains your commit and my commit).

If this is too weird or confusing for you, then just close this pull request, and I'll create another pull request to typeshed with only my commit in it once yours is merged.